### PR TITLE
chore(baseclient): add retry with expo backoff _call + update deps

### DIFF
--- a/lumapps/api/decorators.py
+++ b/lumapps/api/decorators.py
@@ -1,3 +1,4 @@
+import time
 from functools import wraps
 from logging import debug
 from typing import Sequence
@@ -9,6 +10,52 @@ from lumapps.api.errors import (
     UrlAlreadyExistsError,
     get_http_err_content,
 )
+
+
+def retry(exceptions, total_tries=4, initial_wait=0.5, backoff_factor=2):
+    """
+    calling the decorated function applying an exponential backoff.
+    Args:
+        exceptions: Exeption(s) that trigger a retry, can be a tuble
+        total_tries: Total tries
+        initial_wait: Time to first retry
+        backoff_factor: Backoff multiplier 
+        (e.g. value of 2 will double the delay each retry).
+        logger: logger to be used, if none specified print
+    """
+
+    def retry_decorator(f):
+        @wraps(f)
+        def func_with_retries(*args, **kwargs):
+            _tries, _delay = total_tries + 1, initial_wait
+            while _tries > 1:
+                try:
+                    debug(f"{total_tries + 2 - _tries}. try:")
+                    return f(*args, **kwargs)
+                except exceptions as e:
+                    _tries -= 1
+                    print_args = args if args else "no args"
+                    if _tries == 1:
+                        msg = str(
+                            f"Function: {f.__name__}\n"
+                            f"Failed despite best efforts after {total_tries} tries.\n"
+                            f"args: {print_args}, kwargs: {kwargs}"
+                        )
+                        debug(msg)
+                        raise
+                    msg = str(
+                        f"Function: {f.__name__}\n"
+                        f"Exception: {e}\n"
+                        f"""Retrying in {_delay} seconds!, 
+                        args: {print_args}, kwargs: {kwargs}\n"""
+                    )
+                    debug(msg)
+                    time.sleep(_delay)
+                    _delay *= backoff_factor
+
+        return func_with_retries
+
+    return retry_decorator
 
 
 def none_on_http_codes(codes=(404,)):

--- a/lumapps/api/decorators.py
+++ b/lumapps/api/decorators.py
@@ -1,8 +1,7 @@
 import time
-from dataclasses import dataclass
 from functools import wraps
 from logging import debug
-from typing import Sequence, Tuple, Type
+from typing import NamedTuple, Sequence, Tuple, Type
 
 from httpx import HTTPStatusError
 
@@ -13,8 +12,7 @@ from lumapps.api.errors import (
 )
 
 
-@dataclass
-class RetryConfig:
+class RetryConfig(NamedTuple):  # NamedTuple because we support python3.6+
     exceptions: Tuple[Type[Exception]]  # Exceptions tuple
     total_tries: int
     initial_wait: float


### PR DESCRIPTION
Update deps to update cryptography (security update).
Add a configurable retry policy on each call. 
Defaults to 3 retries with a backoff of 2 starting from 0.5s (so, 0.5s => 1s => 2s). and only on HttpsStatusError (httpx error).