### PR TITLE
chore(ci): update ci deps versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Python 3.6 🐍
-        uses: actions/setup-python@v1.1.1
+        uses: actions/setup-python@v2.1.4
         with:
           python-version: 3.6
       
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Python ${{ matrix.python-version }} 🐍
-        uses: actions/setup-python@v1.1.1
+        uses: actions/setup-python@v2.1.4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
 
       - name: Setup Python 3.6 🐍
         uses: actions/setup-python@v2.1.4
@@ -20,7 +20,7 @@ jobs:
           python-version: 3.6
       
       - name: Install Poetry
-        uses: dschep/install-poetry-action@v1.2
+        uses: snok/install-poetry@v1.1.1
 
       - uses: actions/cache@v1
         name: Cache Poetry deps
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
 
       - name: Setup Python ${{ matrix.python-version }} 🐍
         uses: actions/setup-python@v2.1.4
@@ -64,7 +64,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        uses: dschep/install-poetry-action@v1.2
+        uses: snok/install-poetry@v1.1.1
 
       - uses: actions/cache@v1
         name: Cache Poetry deps
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == 3.7
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v1.0.15
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/commit-message-validator.yml
+++ b/.github/workflows/commit-message-validator.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
 
       - name: Commit message validation
         uses: lumapps/commit-message-validator@master

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
 
@@ -24,7 +24,7 @@ jobs:
           python-version: 3.7
       
       - name: Install Poetry
-        uses: dschep/install-poetry-action@v1.2
+        uses: snok/install-poetry@v1.1.1
 
       - uses: actions/cache@v1
         name: Cache Poetry deps

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python 3.7 🐍
-        uses: actions/setup-python@v1.1.1
+        uses: actions/setup-python@v2.1.4
         with:
           python-version: 3.7
       

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Python 3.7 🐍
-        uses: actions/setup-python@v1.1.1
+        uses: actions/setup-python@v2.1.4
         with:
           python-version: 3.7
       

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
 
       - name: Setup Python 3.7 🐍
         uses: actions/setup-python@v2.1.4
@@ -22,7 +22,7 @@ jobs:
           python-version: 3.7
       
       - name: Install Poetry
-        uses: dschep/install-poetry-action@v1.2
+        uses: snok/install-poetry@v1.1.1
 
       - uses: actions/cache@v1
         name: Cache Poetry deps

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
           


### PR DESCRIPTION
Update ci to mitigate https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.
This is to avoid ci failures related to this depreciation