### PR TITLE
hotfix(lumapps-sdk): fix JWT invalid signature

### DIFF
--- a/lumapps/api/lumapps_jwt.py
+++ b/lumapps/api/lumapps_jwt.py
@@ -24,6 +24,7 @@ JWKS_URL = {
     "dot-lumapps-dev.appspot.com": "https://login.dev.lumapps.com/v1/jwks",
     "dot-lumapps-sandbox.appspot.com": "https://login-sandbox.dev.lumapps.com/v1/jwks",
     "dot-lumapps-staging.appspot.com": "https://login.stag.lumapps.com/v1/jwks",
+    "lumapps-staging.appspot.com": "https://login.stag.lumapps.com/v1/jwks",
     "sites-staging.lumapps.com": "https://login.stag.lumapps.com/v1/jwks",
     "sites-analytics.lumapps.com": "https://login.dev.lumapps.com/v1/jwks",
     "sites-ba.lumapps.com": "https://login.dev.lumapps.com/v1/jwks",


### PR DESCRIPTION
Hotfix for journey about the JWT invalid signature.

---


Tested with a temporary test: 

```
def test_hotfix_JWT_invalid_signature():
    token = b"<copy JWT here w/o Bearer at the begining>"
    payload = LumappsJWT(lumapps_url="http://lumapps-staging.appspot.com/").decode(token)
```
    
in `lumapps-sdk/tests/legacy/test_lumapps_jwt.py`