### PR TITLE
chore(client): get unique discovery file and update urls

### DIFF
--- a/lumapps/api/base_client.py
+++ b/lumapps/api/base_client.py
@@ -199,11 +199,11 @@ class BaseClient(AbstractContextManager):
 
             discovery_base_url = urlparse(resp_doc["baseUrl"])
             resp_doc["baseUrl"] = discovery_base_url._replace(
-                netloc=self.base_url
+                netloc=urlparse(self.base_url).netloc
             ).geturl()
             discovery_root_url = urlparse(resp_doc["rootUrl"])
             resp_doc["rootUrl"] = discovery_root_url._replace(
-                netloc=self.base_url
+                netloc=urlparse(self.base_url).netloc
             ).geturl()
 
             get_discovery_cache().set(url, resp_doc)

--- a/lumapps/api/base_client.py
+++ b/lumapps/api/base_client.py
@@ -70,28 +70,9 @@ def _get_discovery_urls(base_url: str, api_info: Dict[str, str]) -> Tuple[str, s
         api_host = urlparse(base_url).netloc.split(".")
         if len(api_host) < 4:
             raise BaseClientError(f"Invalid base URL: {base_url}")
-        is_beta_cell = api_host[1] == "beta"
-        cell = api_host[0]
-        if is_beta_cell and cell not in (
-            "go-cell-001",
-            "go-cell-003",
-            "ms-cell-001",
-        ):
-            raise BaseClientError(f"Invalid LumApps cell in base URL: {cell}")
-
-        if cell not in (
-            "go-cell-001",
-            "go-cell-002",
-            "go-cell-003",
-            "go-cell-005",
-            "go-cell-600",
-            "ms-cell-001",
-            "ms-cell-002",
-        ):
-            raise BaseClientError(f"Invalid LumApps cell in base URL: {cell}")
         return (
             "https://storage.googleapis.com/prod-frontend-static-assets/api-discovery/"
-            f"lumapps-discovery-{'beta-' if is_beta_cell else ''}{cell}.json",
+            "lumapps-discovery-go-cell-001.json",
             api_url,
         )
     return (
@@ -215,6 +196,16 @@ class BaseClient(AbstractContextManager):
         else:
             resp = self.client.get(url)
             resp_doc = resp.json()
+
+            discovery_base_url = urlparse(resp_doc["baseUrl"])
+            resp_doc["baseUrl"] = discovery_base_url._replace(
+                netloc=self.base_url
+            ).geturl()
+            discovery_root_url = urlparse(resp_doc["rootUrl"])
+            resp_doc["rootUrl"] = discovery_root_url._replace(
+                netloc=self.base_url
+            ).geturl()
+
             get_discovery_cache().set(url, resp_doc)
             return resp_doc
 

--- a/lumapps/api/client.py
+++ b/lumapps/api/client.py
@@ -79,6 +79,10 @@ class LumAppsClient(BaseClient):  # pragma: no cover
             self.cache = DiscoveryCacheDict()
         self.dry_run = dry_run
         self._langs = None
+        extra_http_headers = {
+            **({"LumApps-Organization-Id": str(self.customer_id)}),
+            **(extra_http_headers or {}),
+        }
         super().__init__(
             api_info,
             auth_info=auth_info,

--- a/tests/legacy/test_base_client.py
+++ b/tests/legacy/test_base_client.py
@@ -385,7 +385,7 @@ def test_get_new_client_as_using_dwd(cli: BaseClient):
     ("go-cell-002", {"base_url": "https://go-cell-002.api.lumapps.com/"}, None),
     ("ms-cell-001", {"base_url": "https://ms-cell-001.api.lumapps.com/"}, None),
     ("go-cell-003", {"base_url": "https://go-cell-003.beta.api.lumapps.com/"}, None),
-    ("go-cell-004", {"base_url": "https://go-cell-004.api.lumapps.com/"}, BaseClientError),
+    ("go-cell-004", {"base_url": "https://go-cell-004.lumapps.com/"}, BaseClientError),
     ("go-cell-001", {"base_url": "http://localhost/sdk"}, BaseClientError),
     ("go-cell-001", {}, BaseClientError),
 ])
@@ -415,13 +415,3 @@ def test_create_client(cell: str, api_info: Dict[str, str], expected_exception: 
         "authorization": "Bearer None"
     }
     assert client.base_url == api_info["base_url"].rstrip("/")
-    if ".beta." in client.base_url:
-        assert client._discovery_url == (
-            "https://storage.googleapis.com/prod-frontend-static-assets/api-discovery/"
-            f"lumapps-discovery-beta-{cell}.json"
-        )
-    else:
-        assert client._discovery_url == (
-            "https://storage.googleapis.com/prod-frontend-static-assets/api-discovery/"
-            f"lumapps-discovery-{cell}.json"
-        )


### PR DESCRIPTION
in order to be less restrictive on the url to get the discovery file content, we get the same file independently from the base_url and update the file content with the baseUrl on load.